### PR TITLE
Keycard attribute resolver and fixes for integration tests

### DIFF
--- a/lib/keycard.rb
+++ b/lib/keycard.rb
@@ -9,3 +9,5 @@ end
 
 require "keycard/db"
 require "keycard/railtie" if defined?(Rails)
+require "keycard/request_attributes"
+require "keycard/institution_finder"

--- a/lib/keycard/institution_finder.rb
+++ b/lib/keycard/institution_finder.rb
@@ -20,7 +20,7 @@ module Keycard
             AND dlpsDeleted = 'f' )
     SQL
 
-    def initialize(db:)
+    def initialize(db: Keycard::DB.db)
       @db = db
       @stmt = @db[INST_QUERY, *[:$client_ip] * 4].prepare(:select, :unused)
     end
@@ -31,7 +31,7 @@ module Keycard
       insts = insts_for_ip(numeric_ip)
 
       if !insts.empty?
-        { 'dlpsInstitutionIds' => insts }
+        { 'dlpsInstitutionId' => insts }
       else
         {}
       end

--- a/lib/keycard/request_attributes.rb
+++ b/lib/keycard/request_attributes.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Keycard
+  # This class is responsible for extracting the user attributes (i.e. the
+  # complete set of things that determine the user's #identity), given a Rack
+  # request.
+  class RequestAttributes
+    def initialize(request, finder: InstitutionFinder.new)
+      @finder = finder
+      @request = request
+    end
+
+    def [](attr)
+      all[attr]
+    end
+
+    def all
+      finder.attributes_for(request)
+    end
+
+    private
+
+    attr_reader :finder
+    attr_reader :request
+  end
+end

--- a/spec/keycard/institution_finder_spec.rb
+++ b/spec/keycard/institution_finder_spec.rb
@@ -5,8 +5,6 @@ require "sequel_helper"
 require "ipaddr"
 
 RSpec.describe Keycard::InstitutionFinder, DB: true do
-  subject { described_class.new }
-
   describe "#attributes_for" do
     let(:request) { double(:request) }
 
@@ -34,45 +32,45 @@ RSpec.describe Keycard::InstitutionFinder, DB: true do
         .and_return(client_ip)
     end
 
-    subject { described_class.new(db: Keycard::DB.db).attributes_for(request) }
+    let(:attributes) { described_class.new.attributes_for(request) }
 
     context "with an ip with a single institution" do
       let(:client_ip) { "10.0.0.1" }
 
-      it "returns a hash with (only) a dlpsInstitutionIds key" do
-        expect(subject.keys).to contain_exactly('dlpsInstitutionIds')
+      it "returns a hash with (only) a dlpsInstitutionId key" do
+        expect(attributes.keys).to contain_exactly('dlpsInstitutionId')
       end
 
       it "returns the correct institution" do
-        expect(subject['dlpsInstitutionIds']).to contain_exactly(1)
+        expect(attributes['dlpsInstitutionId']).to contain_exactly(1)
       end
     end
 
     context "with an ip with multiple institutions" do
       let(:client_ip) { "10.0.1.1" }
       it "returns the set of institutions" do
-        expect(subject['dlpsInstitutionIds']).to contain_exactly(1, 2)
+        expect(attributes['dlpsInstitutionId']).to contain_exactly(1, 2)
       end
     end
 
     context "with an IP address allowed and denied in the same institituion" do
       let(:client_ip) { "10.0.2.1" }
       it "returns an empty hash" do
-        expect(subject).to eq({})
+        expect(attributes).to eq({})
       end
     end
 
     context "with an IP address allowed in two insts and denied in one of them" do
       let(:client_ip) { "10.0.3.1" }
       it "returns the institution it wasn't denied from" do
-        expect(subject['dlpsInstitutionIds']).to contain_exactly(2)
+        expect(attributes['dlpsInstitutionId']).to contain_exactly(2)
       end
     end
 
     context "with an ip address not in any ranges" do
       let(:client_ip) { "192.168.0.1" }
       it "returns an empty hash" do
-        expect(subject).to eq({})
+        expect(attributes).to eq({})
       end
     end
 
@@ -80,7 +78,7 @@ RSpec.describe Keycard::InstitutionFinder, DB: true do
       let(:client_ip) { "10.0.324.456" }
 
       it "returns an empty hash" do
-        expect(subject).to eq({})
+        expect(attributes).to eq({})
       end
     end
 
@@ -88,7 +86,7 @@ RSpec.describe Keycard::InstitutionFinder, DB: true do
       let(:client_ip) { nil }
 
       it "returns an empty hash" do
-        expect(subject).to eq({})
+        expect(attributes).to eq({})
       end
     end
   end

--- a/spec/keycard/request_attribute_spec.rb
+++ b/spec/keycard/request_attribute_spec.rb
@@ -3,10 +3,6 @@
 require "keycard/request_attributes"
 
 module Keycard
-  class FakeInstFinder
-    def attributes_for(request); end
-  end
-
   RSpec.describe RequestAttributes do
     let(:request) { double(:request) }
     let(:attributes) { {} }

--- a/spec/keycard/request_attribute_spec.rb
+++ b/spec/keycard/request_attribute_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "keycard/request_attributes"
+
+module Keycard
+  class FakeInstFinder
+    def attributes_for(request); end
+  end
+
+  RSpec.describe RequestAttributes do
+    let(:request) { double(:request) }
+    let(:attributes) { {} }
+    let(:finder) { double(:finder, attributes_for: attributes) }
+    let(:request_attributes) { described_class.new(request, finder: finder) }
+
+    it "takes a request" do
+      expect(request_attributes).not_to be(nil)
+    end
+
+    context "with a finder that returns an attribute" do
+      let(:attributes) { { foo: 'bar' } }
+
+      it "can get the value of that attribute" do
+        expect(request_attributes[:foo]).to eq('bar')
+      end
+    end
+
+    describe "#all" do
+      let(:attributes) { { foo: 'bar', baz: 'quux' } }
+
+      it "returns all the attributes" do
+        expect(request_attributes.all).to eq(attributes)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add RequestAttributes - given a request, this collects the attributes
from all the attribute generators (currently just InstitutionFinder, but
eventually more) and is essentially the entry point to Keycard.

This also:

- fixes some requires at the top level
- changes 'subject' to 'attributes' in one of the specs
- sets the default database in the InstitutionFinder
- singularizes dlpsInstitutionId