### PR TITLE
Clean up identity/supplemental attribute handling

### DIFF
--- a/lib/keycard/institution_finder.rb
+++ b/lib/keycard/institution_finder.rb
@@ -5,6 +5,8 @@ require 'ipaddr'
 module Keycard
   # looks up institution ID(s) by IP address
   class InstitutionFinder
+    IDENTITY_ATTRS = %i[dlpsInstitutionId]
+
     INST_QUERY = <<~SQL
         SELECT inst FROM aa_network WHERE
                 ? >= dlpsAddressStart
@@ -25,13 +27,17 @@ module Keycard
       @stmt = @db[INST_QUERY, *[:$client_ip] * 4].prepare(:select, :unused)
     end
 
+    def identity_keys
+      IDENTITY_ATTRS
+    end
+
     def attributes_for(request)
       return {} unless (numeric_ip = numeric_ip(request.client_ip))
 
       insts = insts_for_ip(numeric_ip)
 
       if !insts.empty?
-        { 'dlpsInstitutionId' => insts }
+        { dlpsInstitutionId: insts }
       else
         {}
       end

--- a/lib/keycard/request/cosign_attributes.rb
+++ b/lib/keycard/request/cosign_attributes.rb
@@ -7,8 +7,16 @@ module Keycard
     # the pid/eid are the same and there are currently no additional
     # attributes extracted.
     class CosignAttributes < Attributes
+      def base
+        {
+          user_pid:  user_pid,
+          user_eid:  user_eid,
+          client_ip: client_ip
+        }
+      end
+
       def user_pid
-        request.env['HTTP_X_REMOTE_USER'] || ''
+        request.env['HTTP_X_REMOTE_USER']
       end
 
       def user_eid
@@ -16,7 +24,7 @@ module Keycard
       end
 
       def client_ip
-        (request.env['HTTP_X_FORWARDED_FOR'] || '').split(',').first || ''
+        (request.env['HTTP_X_FORWARDED_FOR'] || '').split(',').first
       end
     end
   end

--- a/lib/keycard/request/direct_attributes.rb
+++ b/lib/keycard/request/direct_attributes.rb
@@ -6,8 +6,16 @@ module Keycard
     # serve HTTP requests directly or through a proxy that passes trusted
     # values into the application environment to be accessed as usual.
     class DirectAttributes < Attributes
+      def base
+        {
+          user_pid:  user_pid,
+          user_eid:  user_eid,
+          client_ip: client_ip
+        }
+      end
+
       def user_pid
-        request.env['REMOTE_USER'] || ''
+        request.env['REMOTE_USER']
       end
 
       def user_eid
@@ -15,7 +23,7 @@ module Keycard
       end
 
       def client_ip
-        (request.env['REMOTE_ADDR'] || '').split(',').first || ''
+        (request.env['REMOTE_ADDR'] || '').split(',').first
       end
     end
   end

--- a/lib/keycard/request/proxied_attributes.rb
+++ b/lib/keycard/request/proxied_attributes.rb
@@ -10,8 +10,16 @@ module Keycard
     # which, somewhat confusingly, are transposed into HTTP_X_REMOTE_USER and
     # HTTP_X_FORWARDED_FOR once the Rack request is assembled.
     class ProxiedAttributes < Attributes
+      def base
+        {
+          user_pid:  user_pid,
+          user_eid:  user_eid,
+          client_ip: client_ip
+        }
+      end
+
       def user_pid
-        request.env['HTTP_X_REMOTE_USER'] || ''
+        request.env['HTTP_X_REMOTE_USER']
       end
 
       def user_eid
@@ -19,7 +27,7 @@ module Keycard
       end
 
       def client_ip
-        (request.env['HTTP_X_FORWARDED_FOR'] || '').split(',').first || ''
+        (request.env['HTTP_X_FORWARDED_FOR'] || '').split(',').first
       end
     end
   end

--- a/lib/keycard/request/shibboleth_attributes.rb
+++ b/lib/keycard/request/shibboleth_attributes.rb
@@ -12,30 +12,75 @@ module Keycard
     class ShibbolethAttributes < Attributes
       def base
         {
-          user_pid:  user_pid,
-          user_eid:  user_eid,
-          client_ip: client_ip
+          user_pid:     user_pid,
+          user_eid:     user_eid,
+          client_ip:    client_ip,
+          email:        email,
+          display_name: display_name,
+          affiliation:  affiliation,
+          authn_method: authn_context,
+          provider:     provider,
+        }
+      end
+
+      def verbatim
+        {
+          persistentNameID:           persistent_id,
+          eduPersonPrincipalName:     principal_name,
+          eduPersonScopedAffiliation: affiliation,
+          displayName:                display_name,
+          mail:                       email,
+          authnContextClassRef:       authn_context,
+          authenticationMethod:       authn_method,
         }
       end
 
       def user_pid
-        get('HTTP_X_SHIB_PERSISTENT_ID')
+        persistent_id
       end
 
       def user_eid
-        get('HTTP_X_SHIB_EDUPERSONPRINCIPALNAME')
+        principal_name
       end
 
       def client_ip
         safe('HTTP_X_FORWARDED_FOR').split(',').first
       end
 
-      def display_name
-        get('HTTP_X_SHIB_DISPLAYNAME')
+      def persistent_id
+        get 'HTTP_X_SHIB_PERSISTENT_ID'
       end
 
-      def scoped_affiliation
+      def principal_name
+        get 'HTTP_X_SHIB_EDUPERSONPRINCIPALNAME'
+      end
+
+      def display_name
+        get 'HTTP_X_SHIB_DISPLAYNAME'
+      end
+
+      def email
+        get 'HTTP_X_SHIB_MAIL'
+      end
+
+      def affiliation
         safe('HTTP_X_SHIB_EDUPERSONSCOPEDAFFILIATION').split(';')
+      end
+
+      def authn_method
+        get 'HTTP_X_SHIB_AUTHENTICATION_METHOD'
+      end
+
+      def authn_context
+        get 'HTTP_X_SHIB_AUTHNCONTEXT_CLASS'
+      end
+
+      def provider
+        get 'HTTP_X_SHIB_IDENTITY_PROVIDER'
+      end
+
+      def identity_keys
+        %i[user_pid user_eid affiliation]
       end
 
       private

--- a/lib/keycard/request/shibboleth_attributes.rb
+++ b/lib/keycard/request/shibboleth_attributes.rb
@@ -11,40 +11,41 @@ module Keycard
     # requests, and the user_pid, for requests from authenticated users.
     class ShibbolethAttributes < Attributes
       def base
-        super.merge(shib_attributes)
+        {
+          user_pid:  user_pid,
+          user_eid:  user_eid,
+          client_ip: client_ip
+        }
       end
 
       def user_pid
-        getenv('HTTP_X_SHIB_PERSISTENT_ID')
+        get('HTTP_X_SHIB_PERSISTENT_ID')
       end
 
       def user_eid
-        getenv('HTTP_X_SHIB_EDUPERSONPRINCIPALNAME')
+        get('HTTP_X_SHIB_EDUPERSONPRINCIPALNAME')
       end
 
       def client_ip
-        getenv('HTTP_X_FORWARDED_FOR').split(',').first || ''
+        safe('HTTP_X_FORWARDED_FOR').split(',').first
       end
 
       def display_name
-        getenv('HTTP_X_SHIB_DISPLAYNAME')
+        get('HTTP_X_SHIB_DISPLAYNAME')
       end
 
       def scoped_affiliation
-        getenv('HTTP_X_SHIB_EDUPERSONSCOPEDAFFILIATION').split(';')
+        safe('HTTP_X_SHIB_EDUPERSONSCOPEDAFFILIATION').split(';')
       end
 
       private
 
-      def getenv(key)
-        request.env[key] || ''
+      def get(key)
+        request.env[key]
       end
 
-      def shib_attributes
-        {
-          displayName: display_name,
-          eduPersonScopedAffiliation: scoped_affiliation
-        }
+      def safe(key)
+        get(key) || ''
       end
     end
   end

--- a/lib/keycard/request/shibboleth_attributes.rb
+++ b/lib/keycard/request/shibboleth_attributes.rb
@@ -12,19 +12,9 @@ module Keycard
     class ShibbolethAttributes < Attributes
       def base
         {
-          user_pid:     user_pid,
-          user_eid:     user_eid,
-          client_ip:    client_ip,
-          email:        email,
-          display_name: display_name,
-          affiliation:  affiliation,
-          authn_method: authn_context,
-          provider:     provider,
-        }
-      end
-
-      def verbatim
-        {
+          user_pid:                   user_pid,
+          user_eid:                   user_eid,
+          client_ip:                  client_ip,
           persistentNameID:           persistent_id,
           eduPersonPrincipalName:     principal_name,
           eduPersonScopedAffiliation: affiliation,
@@ -32,6 +22,7 @@ module Keycard
           mail:                       email,
           authnContextClassRef:       authn_context,
           authenticationMethod:       authn_method,
+          identity_provider:          identity_provider
         }
       end
 
@@ -75,12 +66,12 @@ module Keycard
         get 'HTTP_X_SHIB_AUTHNCONTEXT_CLASS'
       end
 
-      def provider
+      def identity_provider
         get 'HTTP_X_SHIB_IDENTITY_PROVIDER'
       end
 
       def identity_keys
-        %i[user_pid user_eid affiliation]
+        %i[user_pid user_eid eduPersonScopedAffiliation]
       end
 
       private

--- a/spec/keycard/institution_finder_spec.rb
+++ b/spec/keycard/institution_finder_spec.rb
@@ -5,6 +5,12 @@ require "sequel_helper"
 require "ipaddr"
 
 RSpec.describe Keycard::InstitutionFinder, DB: true do
+  # Should become a shared example for finders when we add more
+  it "lists its identity keys" do
+    finder = described_class.new
+    expect(finder.identity_keys).to eq [:dlpsInstitutionId]
+  end
+
   describe "#attributes_for" do
     let(:request) { double(:request, client_ip: client_ip) }
 
@@ -34,18 +40,18 @@ RSpec.describe Keycard::InstitutionFinder, DB: true do
       let(:client_ip) { "10.0.0.1" }
 
       it "returns a hash with (only) a dlpsInstitutionId key" do
-        expect(attributes.keys).to contain_exactly('dlpsInstitutionId')
+        expect(attributes.keys).to contain_exactly(:dlpsInstitutionId)
       end
 
       it "returns the correct institution" do
-        expect(attributes['dlpsInstitutionId']).to contain_exactly(1)
+        expect(attributes[:dlpsInstitutionId]).to contain_exactly(1)
       end
     end
 
     context "with an ip with multiple institutions" do
       let(:client_ip) { "10.0.1.1" }
       it "returns the set of institutions" do
-        expect(attributes['dlpsInstitutionId']).to contain_exactly(1, 2)
+        expect(attributes[:dlpsInstitutionId]).to contain_exactly(1, 2)
       end
     end
 
@@ -59,7 +65,7 @@ RSpec.describe Keycard::InstitutionFinder, DB: true do
     context "with an IP address allowed in two insts and denied in one of them" do
       let(:client_ip) { "10.0.3.1" }
       it "returns the institution it wasn't denied from" do
-        expect(attributes['dlpsInstitutionId']).to contain_exactly(2)
+        expect(attributes[:dlpsInstitutionId]).to contain_exactly(2)
       end
     end
 

--- a/spec/keycard/request/cosign_attributes_spec.rb
+++ b/spec/keycard/request/cosign_attributes_spec.rb
@@ -34,15 +34,15 @@ RSpec.describe Keycard::Request::CosignAttributes do
     let(:attributes) { described_class.new(request) }
 
     it "the user_pid is empty" do
-      expect(attributes.user_pid).to eq ''
+      expect(attributes.user_pid).to be_nil
     end
 
     it "the user_eid is empty" do
-      expect(attributes.user_eid).to eq ''
+      expect(attributes.user_eid).to be_nil
     end
 
-    it "the client_ip is empty" do
-      expect(attributes.client_ip).to eq ''
+    it "the client_ip is empty (though this would be a proxy config error)" do
+      expect(attributes.client_ip).to be_nil
     end
   end
 

--- a/spec/keycard/request/proxied_attributes_spec.rb
+++ b/spec/keycard/request/proxied_attributes_spec.rb
@@ -34,15 +34,15 @@ RSpec.describe Keycard::Request::ProxiedAttributes do
     let(:request) { described_class.new(base) }
 
     it "the user_pid is empty" do
-      expect(request.user_pid).to eq ''
+      expect(request.user_pid).to be_nil
     end
 
     it "the user_eid is empty" do
-      expect(request.user_eid).to eq ''
+      expect(request.user_eid).to be_nil
     end
 
     it "the client_ip is empty" do
-      expect(request.client_ip).to eq ''
+      expect(request.client_ip).to be_nil
     end
   end
 

--- a/spec/keycard/request/shibboleth_attributes_spec.rb
+++ b/spec/keycard/request/shibboleth_attributes_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe Keycard::Request::ShibbolethAttributes do
     end
 
     describe '#all' do
-      it "includes displayName" do
+      xit "includes displayName" do
         expect(attributes[:displayName]).to eq 'Aardvark Jones'
       end
 
-      it "includes displayName" do
+      xit "includes displayName" do
         expect(attributes[:eduPersonScopedAffiliation]).to contain_exactly(
           'member@default.invalid', 'staff@default.invalid'
         )
@@ -47,15 +47,15 @@ RSpec.describe Keycard::Request::ShibbolethAttributes do
     let(:attributes) { described_class.new(request) }
 
     it "the user_pid is empty" do
-      expect(attributes.user_pid).to eq ''
+      expect(attributes.user_pid).to be_nil
     end
 
     it "the user_eid is empty" do
-      expect(attributes.user_eid).to eq ''
+      expect(attributes.user_eid).to be_nil
     end
 
     it "the client_ip is empty" do
-      expect(attributes.client_ip).to eq ''
+      expect(attributes.client_ip).to be_nil
     end
   end
 

--- a/spec/keycard/request/shibboleth_attributes_spec.rb
+++ b/spec/keycard/request/shibboleth_attributes_spec.rb
@@ -46,11 +46,11 @@ RSpec.describe Keycard::Request::ShibbolethAttributes do
       expect(attributes.authn_method).to eq 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'
     end
 
-    it "uses the identity provider URL as provider" do
-      expect(attributes.provider).to eq 'https://idp.default.invalid/shib/idp'
+    it "uses the identity provider URL as identity_provider" do
+      expect(attributes.identity_provider).to eq 'https://idp.default.invalid/shib/idp'
     end
 
-    it "uses the identity provider URL as provider" do
+    it "uses the forwarded for header as client_ip" do
       expect(attributes.client_ip).to eq '10.0.0.1'
     end
 
@@ -67,58 +67,38 @@ RSpec.describe Keycard::Request::ShibbolethAttributes do
         expect(attributes[:client_ip]).not_to be_nil
       end
 
-      it "includes email" do
-        expect(attributes[:email]).not_to be_nil
+      it "includes identity_provider" do
+        expect(attributes[:identity_provider]).not_to be_nil
       end
-
-      it "includes display_name" do
-        expect(attributes[:display_name]).not_to be_nil
-      end
-
-      it "includes affiliation" do
-        expect(attributes[:affiliation]).not_to be_nil
-      end
-
-      it "includes authn_method" do
-        expect(attributes[:authn_method]).not_to be_nil
-      end
-
-      it "includes provider" do
-        expect(attributes[:provider]).not_to be_nil
-      end
-    end
-
-    describe '#verbatim' do
-      let(:verbatim) { attributes.verbatim }
 
       it "includes persistentNameID" do
-        expect(verbatim[:persistentNameID]).not_to be_nil
+        expect(attributes[:persistentNameID]).not_to be_nil
       end
 
       it "includes eduPersonPrincipalName" do
-        expect(verbatim[:eduPersonPrincipalName]).not_to be_nil
+        expect(attributes[:eduPersonPrincipalName]).not_to be_nil
       end
 
       it "includes eduPersonScopedAffiliation" do
-        expect(verbatim[:eduPersonScopedAffiliation]).not_to be_nil
+        expect(attributes[:eduPersonScopedAffiliation]).not_to be_nil
       end
 
       it "includes mail" do
-        expect(verbatim[:mail]).not_to be_nil
+        expect(attributes[:mail]).not_to be_nil
       end
 
       it "includes authnContextClassRef" do
-        expect(verbatim[:authnContextClassRef]).not_to be_nil
+        expect(attributes[:authnContextClassRef]).not_to be_nil
       end
 
       it "includes authenticationMethod" do
-        expect(verbatim[:authenticationMethod]).not_to be_nil
+        expect(attributes[:authenticationMethod]).not_to be_nil
       end
     end
 
     describe "#identity" do
       it "includes only user_pid, user_eid and affiliation" do
-        expect(attributes.identity.keys).to contain_exactly(:user_pid, :user_eid, :affiliation)
+        expect(attributes.identity.keys).to contain_exactly(:user_pid, :user_eid, :eduPersonScopedAffiliation)
       end
     end
   end

--- a/spec/keycard/request/shibboleth_attributes_spec.rb
+++ b/spec/keycard/request/shibboleth_attributes_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Keycard::Request::ShibbolethAttributes do
         'HTTP_X_SHIB_PERSISTENT_ID' => 'https://idp.default.invalid/shib/idp!https://sp.default.invalid/shib/sp!asfgkjhlk',
         'HTTP_X_SHIB_AUTHENTICATION_METHOD' => 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
         'HTTP_X_SHIB_AUTHNCONTEXT_CLASS' => 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
-        'HTTP_X_SHIB_IDENTITY_PROVIDER' => 'https://idp.default.invalid/shib/idp'
+        'HTTP_X_SHIB_IDENTITY_PROVIDER' => 'https://idp.default.invalid/shib/idp',
+        'HTTP_X_FORWARDED_FOR' => '10.0.0.1'
        })
     end
 
@@ -29,15 +30,95 @@ RSpec.describe Keycard::Request::ShibbolethAttributes do
       expect(attributes.user_eid).to eq 'someuser@default.invalid'
     end
 
+    it "uses the mail for email" do
+      expect(attributes.email).to eq 'someuser@mail.default.invalid'
+    end
+
+    it "uses the displayName for display_name" do
+      expect(attributes.display_name).to eq 'Aardvark Jones'
+    end
+
+    it "uses the eduPersonScopedAffiliation for affiliation" do
+      expect(attributes.affiliation).to eq(['member@default.invalid', 'staff@default.invalid'])
+    end
+
+    it "uses the auth context as method" do
+      expect(attributes.authn_method).to eq 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'
+    end
+
+    it "uses the identity provider URL as provider" do
+      expect(attributes.provider).to eq 'https://idp.default.invalid/shib/idp'
+    end
+
+    it "uses the identity provider URL as provider" do
+      expect(attributes.client_ip).to eq '10.0.0.1'
+    end
+
     describe '#all' do
-      xit "includes displayName" do
-        expect(attributes[:displayName]).to eq 'Aardvark Jones'
+      it "includes user_pid" do
+        expect(attributes[:user_pid]).not_to be_nil
       end
 
-      xit "includes displayName" do
-        expect(attributes[:eduPersonScopedAffiliation]).to contain_exactly(
-          'member@default.invalid', 'staff@default.invalid'
-        )
+      it "includes user_eid" do
+        expect(attributes[:user_eid]).not_to be_nil
+      end
+
+      it "includes client_ip" do
+        expect(attributes[:client_ip]).not_to be_nil
+      end
+
+      it "includes email" do
+        expect(attributes[:email]).not_to be_nil
+      end
+
+      it "includes display_name" do
+        expect(attributes[:display_name]).not_to be_nil
+      end
+
+      it "includes affiliation" do
+        expect(attributes[:affiliation]).not_to be_nil
+      end
+
+      it "includes authn_method" do
+        expect(attributes[:authn_method]).not_to be_nil
+      end
+
+      it "includes provider" do
+        expect(attributes[:provider]).not_to be_nil
+      end
+    end
+
+    describe '#verbatim' do
+      let(:verbatim) { attributes.verbatim }
+
+      it "includes persistentNameID" do
+        expect(verbatim[:persistentNameID]).not_to be_nil
+      end
+
+      it "includes eduPersonPrincipalName" do
+        expect(verbatim[:eduPersonPrincipalName]).not_to be_nil
+      end
+
+      it "includes eduPersonScopedAffiliation" do
+        expect(verbatim[:eduPersonScopedAffiliation]).not_to be_nil
+      end
+
+      it "includes mail" do
+        expect(verbatim[:mail]).not_to be_nil
+      end
+
+      it "includes authnContextClassRef" do
+        expect(verbatim[:authnContextClassRef]).not_to be_nil
+      end
+
+      it "includes authenticationMethod" do
+        expect(verbatim[:authenticationMethod]).not_to be_nil
+      end
+    end
+
+    describe "#identity" do
+      it "includes only user_pid, user_eid and affiliation" do
+        expect(attributes.identity.keys).to contain_exactly(:user_pid, :user_eid, :affiliation)
       end
     end
   end


### PR DESCRIPTION
There are detailed messages and issue references on each of these commits. There are three taste items here that warrant a special call-out: the change of dlpsInstitutionId to a symbol, the change from empty strings to nil values for missing attributes, and the aliases I've chosen as the proposed lingua franca.