### PR TITLE
Add an API key wrapper

### DIFF
--- a/keycard.gemspec
+++ b/keycard.gemspec
@@ -26,14 +26,14 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "sequel"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "coveralls", "~> 0.8"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "coveralls"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "rake", "~> 12.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop", "~> 0.52"
-  spec.add_development_dependency "rubocop-rails", "~> 1.1"
-  spec.add_development_dependency "rubocop-rspec", "~> 1.16"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "rubocop-rails"
+  spec.add_development_dependency "rubocop-rspec"
   spec.add_development_dependency "sqlite3"
-  spec.add_development_dependency "yard", "~> 0.9"
+  spec.add_development_dependency "yard"
 end

--- a/lib/keycard.rb
+++ b/lib/keycard.rb
@@ -13,6 +13,7 @@ module Keycard
   end
 end
 
+require "keycard/digest_key"
 require "keycard/db"
 require "keycard/railtie" if defined?(Rails)
 require "keycard/institution_finder"

--- a/lib/keycard/digest_key.rb
+++ b/lib/keycard/digest_key.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "digest"
+require "securerandom"
+
+# A typical digest or api key, ready to be encrypted.
+class Keycard::DigestKey
+  class HiddenKeyError < StandardError; end
+  HIDDEN_KEY = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX".freeze
+
+  # To simply mint a new key, call #new without any parameters.
+  # For wrapping existing, deserialized keys, pass the digest to the constructor.
+  # @param digest [String] The value of the hashed key
+  # @param key [String] Use this if you'd like to specify the unhashed key.
+  #   If a digest is also provided, this parameter is ignored.
+  def initialize(digest = nil, key: nil)
+    if digest
+      @digest = digest
+    else
+      @key = key || SecureRandom.uuid
+    end
+  end
+
+  # A string representation of this key. For hidden keys, this returns an
+  # obfuscated value.
+  # @return [String]
+  def to_s
+    @key || HIDDEN_KEY
+  end
+
+  # The unhashed value of the key.
+  # @return [String]
+  # @raise [HiddenKeyError] This exception is raised if the unhashed key is
+  #   not available.
+  def value
+    if @key
+      @key
+    else
+      raise HiddenKeyError, "Cannot display hashed/hidden keys"
+    end
+  end
+
+  # The result of hashing the key
+  # @return [String]
+  def digest
+    @digest ||= Digest::SHA256.hexdigest(@key)
+  end
+
+  def eql?(other)
+    digest == if other.is_a?(self.class)
+                other.digest
+              else
+                other.to_s
+              end
+  end
+  alias == eql?
+
+end
+

--- a/lib/keycard/version.rb
+++ b/lib/keycard/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Keycard
-  VERSION = "0.2.4"
+  VERSION = "0.3.0"
 end

--- a/spec/keycard/digest_key_spec.rb
+++ b/spec/keycard/digest_key_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "keycard/digest_key"
+require "securerandom"
+
+RSpec.describe Keycard::DigestKey do
+  let(:hidden_uuid) { "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" }
+  let(:uuid) { SecureRandom.uuid }
+  let(:digest) { Digest::SHA256.hexdigest(uuid) }
+  let(:new_key) { described_class.new(key: uuid) }
+  let(:hidden_key) { described_class.new(digest) }
+
+  describe "#to_s" do
+    it "displays new keys" do
+      expect(new_key.to_s).to eql(uuid)
+    end
+
+    it "hides hidden keys" do
+      expect(hidden_key.to_s).to eql(hidden_uuid)
+    end
+
+    it "defaults to a uuid" do
+      allow(SecureRandom).to receive(:uuid).and_return("a uuid")
+      expect(described_class.new.to_s).to eql("a uuid")
+    end
+  end
+
+  describe "#value" do
+    it "returns the new key" do
+      expect(new_key.value).to eql(uuid)
+    end
+
+    it "throws on a hidden key" do
+      expect { hidden_key.value }
+        .to raise_error described_class::HiddenKeyError
+    end
+  end
+
+  describe "#digest" do
+    it "new keys return the hashed value" do
+      expect(new_key.digest).to eql(digest)
+    end
+
+    it "hidden keys return the hashed value" do
+      expect(hidden_key.digest).to eql(digest)
+    end
+  end
+
+  %i[== eql?].each do |m|
+    describe "##{m}" do
+      it "compares the digest to anything with a to_s method" do
+        thing = Struct.new(:to_s).new(digest)
+        expect(new_key.send(m, thing)).to be true
+      end
+
+      it "instantiates a new key every time" do
+        expect(described_class.new.send(m, described_class.new)).to be false
+      end
+
+      it "new keys are equal if their keys are equal" do
+        expect(described_class.new(key: uuid).send(m, described_class.new(key: uuid)))
+          .to be true
+      end
+
+      it "new keys are unequal if their keys are unequal" do
+        expect(described_class.new(key: uuid).send(m, described_class.new(key: "foo")))
+          .to be false
+      end
+
+      it "new key == hidden key if their digests match" do
+        expect(described_class.new(key: uuid).send(m, described_class.new(digest)))
+          .to be true
+      end
+
+      it "hidden key == new key if their digests match" do
+        expect(described_class.new(digest).send(m, described_class.new(key: uuid)))
+          .to be true
+      end
+
+      it "new key != hidden key if their digests mismatch" do
+        expect(described_class.new(key: uuid).send(m, described_class.new("foo")))
+          .to be false
+      end
+
+      it "hidden key != new key if their digests mismatch" do
+        expect(described_class.new("foo").send(m, described_class.new(key: uuid)))
+          .to be false
+      end
+
+      it "hidden key == hidden key if their digests match" do
+        expect(described_class.new(digest).send(m, described_class.new(digest)))
+          .to be true
+      end
+
+      it "hidden key != hidden key if their digests match" do
+        expect(described_class.new(digest).send(m, described_class.new("foo")))
+          .to be false
+      end
+    end
+  end
+
+end
+


### PR DESCRIPTION
- Removes gem version requirements from the gemfile. This matches best practices for library development.
- Adds the ApiKey class, which provides some convenience methods around generating api_keys and their digests.

Needed for PFDR-106