### PR TITLE
Add clarity to Request::*Attributes specs

### DIFF
--- a/spec/keycard/request/attributes_factory_spec.rb
+++ b/spec/keycard/request/attributes_factory_spec.rb
@@ -27,10 +27,10 @@ end
 module Keycard::Request
   RSpec.describe AttributesFactory do
     access = {
-      'direct'        => DirectAttributes,
-      'proxy'         => ProxiedAttributes,
-      'cosign'        => CosignAttributes,
-      'shibboleth'    => ShibbolethAttributes,
+      'direct' => DirectAttributes,
+      'proxy' => ProxiedAttributes,
+      'cosign' => CosignAttributes,
+      'shibboleth' => ShibbolethAttributes,
       '(any unknown)' => DirectAttributes
     }
     access.each do |mode, klass|

--- a/spec/keycard/request/attributes_spec.rb
+++ b/spec/keycard/request/attributes_spec.rb
@@ -4,104 +4,95 @@ require "sequel_helper"
 require "keycard/request/attributes"
 
 RSpec.describe Keycard::Request::Attributes do
-  let(:inst_attributes) { {} }
+  let(:finder_attributes) { { baz: 'quux', finder_attr: 'value' } }
   let(:finder) do
-    double(:finder, attributes_for: inst_attributes, identity_keys: [:inst_attr])
+    double(:finder, attributes_for: finder_attributes, identity_keys: [:finder_attr])
   end
-
-  let(:user_attributes)    { { username: 'user' } }
-  let(:request)            { double(:request, attributes: user_attributes, client_ip: '10.0.0.1') }
-  let(:request_attributes) { described_class.new(request, finders: [finder]) }
+  let(:rack_request) { double(:rack_request) }
+  let(:attributes) { described_class.new(rack_request, finders: [finder]) }
 
   it "takes a request" do
-    expect(request_attributes).not_to be(nil)
+    expect(attributes).not_to be(nil)
   end
 
-  it "lists combines its identity keys with those of its finders" do
-    expect(request_attributes.identity_keys).to contain_exactly(:user_pid, :user_eid, :inst_attr)
-  end
-
-  it "does not give a value for user_pid" do
-    expect(request_attributes.user_pid).to be nil
-  end
-
-  it "does not give a value for user_eid" do
-    expect(request_attributes.user_eid).to be nil
-  end
-
-  it "does not give a value for client_ip" do
-    expect(request_attributes.client_ip).to be nil
-  end
-
-  it "gives empty base attributes" do
-    expect(request_attributes.base).to eq({})
-  end
-
-  context "with a finder that returns an attribute" do
-    let(:inst_attributes) { { inst_attr: 'value', foo: 'bar' } }
-
-    it "can get the value of an attribute" do
-      expect(request_attributes[:inst_attr]).to eq('value')
+  describe "#identity_keys" do
+    it "includes user_pid and user_eid by default" do
+      expect(described_class.new(double(:r), finders: []).identity_keys)
+        .to contain_exactly(:user_pid, :user_eid)
     end
-
-    it "merges identity attributes according to the finder's identity_keys" do
-      expect(request_attributes.identity[:inst_attr]).to eq 'value'
+    it "lists combines its identity keys with those of its finders" do
+      expect(attributes.identity_keys).to contain_exactly(:user_pid, :user_eid, :finder_attr)
     end
+  end
 
-    it "passes through supplemental attributes" do
-      expect(request_attributes.supplemental[:foo]).to eq('bar')
+  describe "#user_pid" do
+    it { expect(attributes.user_pid).to be nil }
+  end
+
+  describe "#user_eid" do
+    it { expect(attributes.user_eid).to be nil }
+  end
+
+  describe "#client_ip" do
+    it { expect(attributes.client_ip).to be nil }
+  end
+
+  describe "#base" do
+    it "is empty" do
+      expect(attributes.base).to eq({})
+    end
+  end
+
+  describe "#[]" do
+    it "can get the value of a finder attribute" do
+      expect(attributes[:finder_attr]).to eql('value')
     end
   end
 
   describe "#all" do
-    let(:user_attributes) { { username: 'user' } }
-    let(:inst_attributes) { { baz: 'quux' } }
+    let(:base_attributes) { { user_pid: 'pid', user_eid: 'eid', client_ip: '10.0.0.1', zilch: nil } }
+    let(:finder_attributes) { { baz: 'quux', nada: nil } }
+    before(:each) { allow(attributes).to receive(:base).and_return(base_attributes) }
 
-    it "returns only the institutional attribute because pid, eid, and IP are nil" do
-      expect(request_attributes.all).to eq inst_attributes
+    it "ignores nil attributes" do
+      expect(attributes.all.keys).to_not include(:nada, :zilch)
+    end
+
+    it "includes base attributes and those from finders" do
+      expect(attributes.all).to eql(base_attributes.merge(baz: 'quux'))
     end
   end
 
   describe "#identity" do
-    let(:base_attributes) do
-      { user_pid: 'pid', user_eid: 'eid', client_ip: '10.0.0.1' }
-    end
-    let(:inst_attributes) { { baz: 'quux' } }
+    let(:base_attributes) { { user_pid: 'pid', user_eid: 'eid', client_ip: '10.0.0.1' } }
+    before(:each) { allow(attributes).to receive(:base).and_return(base_attributes) }
 
-    it "returns the identity attributes" do
-      allow(request_attributes).to receive(:base).and_return(base_attributes)
-      expect(request_attributes.identity).to eq(user_pid: 'pid', user_eid: 'eid')
+    it "includes pairs according to the identity_keys" do
+      expect(attributes.identity).to eql(
+        user_pid: 'pid',
+        user_eid: 'eid',
+        finder_attr: 'value'
+      )
     end
   end
 
   describe "#supplemental" do
     context "with the default supplemental attributes" do
       let(:base_attributes) { { user_pid: 'user', client_ip: '10.0.0.1' } }
-      let(:inst_attributes) { { baz: 'quux' } }
-      let(:attributes)      { { baz: 'quux' } }
+      before(:each) { allow(attributes).to receive(:base).and_return(base_attributes) }
 
-      it "returns the supplemental attributes" do
-        expect(request_attributes.supplemental).to eq attributes
+      it "returns non-identity attributes" do
+        expect(attributes.supplemental).to eq(baz: 'quux', client_ip: '10.0.0.1')
       end
     end
 
-    context "when Keycard is configured to deliver displayName as a supplemental attribute" do
+    context "with additional supplemental attributes in base attributes" do
       let(:base_attributes) { { user_pid: 'user', aardvarkName: 'Aardvark Jones' } }
-      let(:inst_attributes) { { baz: 'quux' } }
-      let(:attributes)      { { aardvarkName: 'Aardvark Jones', baz: 'quux' } }
-
-      before do
-        @supplemental = Keycard.config.supplemental_attributes
-        Keycard.config.supplemental_attributes = ['aardvarkName']
-      end
-
-      after do
-        Keycard.config.supplemental_attributes = @supplemental
-      end
+      let(:expected) { { aardvarkName: 'Aardvark Jones', baz: 'quux' } }
+      before(:each) { allow(attributes).to receive(:base).and_return(base_attributes) }
 
       it "returns the supplemental attributes" do
-        allow(request_attributes).to receive(:base).and_return(base_attributes)
-        expect(request_attributes.supplemental).to eq attributes
+        expect(attributes.supplemental).to eql(expected)
       end
     end
   end

--- a/spec/keycard/request/cosign_attributes_spec.rb
+++ b/spec/keycard/request/cosign_attributes_spec.rb
@@ -3,14 +3,15 @@
 require "keycard/request/cosign_attributes"
 
 RSpec.describe Keycard::Request::CosignAttributes do
+  let(:attributes) { described_class.new(rack_request) }
+
   context "with typical forwarded headers" do
-    let(:request) do
-      double('request', env: {
+    let(:rack_request) do
+      double(:rack_request, env: {
                'HTTP_X_REMOTE_USER' => 'user',
                'HTTP_X_FORWARDED_FOR' => '10.0.0.1'
              })
     end
-    let(:attributes) { described_class.new(request) }
 
     it "extracts the user_pid from HTTP_X_REMOTE_USER" do
       expect(attributes.user_pid).to eq 'user'
@@ -30,8 +31,7 @@ RSpec.describe Keycard::Request::CosignAttributes do
   end
 
   context "with no forwarded headers" do
-    let(:request)    { double('request', env: {}) }
-    let(:attributes) { described_class.new(request) }
+    let(:rack_request) { double(:rack_request, env: {}) }
 
     it "the user_pid is empty" do
       expect(attributes.user_pid).to be_nil
@@ -41,18 +41,17 @@ RSpec.describe Keycard::Request::CosignAttributes do
       expect(attributes.user_eid).to be_nil
     end
 
-    it "the client_ip is empty (though this would be a proxy config error)" do
+    it "the client_ip is empty" do
       expect(attributes.client_ip).to be_nil
     end
   end
 
   context "with multiple forwarded addresses" do
-    let(:request) do
-      double('request', env: {
+    let(:rack_request) do
+      double(:rack_request, env: {
                'HTTP_X_FORWARDED_FOR' => '10.0.0.2, 10.0.0.1'
              })
     end
-    let(:attributes) { described_class.new(request) }
 
     it "extracts the first address" do
       expect(attributes.client_ip).to eq '10.0.0.2'

--- a/spec/keycard/request/direct_attributes_spec.rb
+++ b/spec/keycard/request/direct_attributes_spec.rb
@@ -3,31 +3,31 @@
 require "keycard/request/direct_attributes"
 
 RSpec.describe Keycard::Request::DirectAttributes do
-  let(:addr)    { '10.0.0.1' }
-  let(:base)    { double('request', env: { 'REMOTE_USER' => 'user', 'REMOTE_ADDR' => addr }) }
-  let(:request) { described_class.new(base) }
+  let(:addr) { '10.0.0.1' }
+  let(:rack_request) { double(:rack_request, env: { 'REMOTE_USER' => 'user', 'REMOTE_ADDR' => addr }) }
+  let(:attributes) { described_class.new(rack_request) }
 
   it "extracts the user_pid from REMOTE_USER" do
-    expect(request.user_pid).to eq 'user'
+    expect(attributes.user_pid).to eq 'user'
   end
 
   it "extracts the user_eid from REMOTE_USER" do
-    expect(request.user_eid).to eq 'user'
+    expect(attributes.user_eid).to eq 'user'
   end
 
   it "extracts the client IP address from REMOTE_ADDR" do
-    expect(request.client_ip).to eq '10.0.0.1'
+    expect(attributes.client_ip).to eq '10.0.0.1'
   end
 
   it "gives a hash of all of the base attributes" do
-    expect(request.all).to eq(user_pid: 'user', user_eid: 'user', client_ip: '10.0.0.1')
+    expect(attributes.all).to eq(user_pid: 'user', user_eid: 'user', client_ip: '10.0.0.1')
   end
 
   context "with multiple remote addresses" do
     let(:addr) { '10.0.0.2, 10.0.0.1' }
 
     it "extracts the first IP from REMOTE_ADDR" do
-      expect(request.client_ip).to eq '10.0.0.2'
+      expect(attributes.client_ip).to eq '10.0.0.2'
     end
   end
 end

--- a/spec/keycard/request/proxied_attributes_spec.rb
+++ b/spec/keycard/request/proxied_attributes_spec.rb
@@ -3,59 +3,58 @@
 require "keycard/request/proxied_attributes"
 
 RSpec.describe Keycard::Request::ProxiedAttributes do
+  let(:attributes) { described_class.new(rack_request) }
+
   context "with typical forwarded headers" do
-    let(:base) do
-      double('base request', env: {
+    let(:rack_request) do
+      double(:rack_request, env: {
                'HTTP_X_REMOTE_USER' => 'user',
                'HTTP_X_FORWARDED_FOR' => '10.0.0.1'
              })
     end
-    let(:request) { described_class.new(base) }
 
     it "extracts the user_pid from HTTP_X_REMOTE_USER" do
-      expect(request.user_pid).to eq 'user'
+      expect(attributes.user_pid).to eq 'user'
     end
 
     it "extracts the user_eid from HTTP_X_REMOTE_USER" do
-      expect(request.user_eid).to eq 'user'
+      expect(attributes.user_eid).to eq 'user'
     end
 
     it "extracts the client IP address from HTTP_X_FORWARDED_FOR" do
-      expect(request.client_ip).to eq '10.0.0.1'
+      expect(attributes.client_ip).to eq '10.0.0.1'
     end
 
     it "gives a hash of all of the base attributes" do
-      expect(request.all).to eq(user_pid: 'user', user_eid: 'user', client_ip: '10.0.0.1')
+      expect(attributes.all).to eq(user_pid: 'user', user_eid: 'user', client_ip: '10.0.0.1')
     end
   end
 
   context "with no forwarded headers" do
-    let(:base)    { double('base request', env: {}) }
-    let(:request) { described_class.new(base) }
+    let(:rack_request) { double(:rack_request, env: {}) }
 
     it "the user_pid is empty" do
-      expect(request.user_pid).to be_nil
+      expect(attributes.user_pid).to be_nil
     end
 
     it "the user_eid is empty" do
-      expect(request.user_eid).to be_nil
+      expect(attributes.user_eid).to be_nil
     end
 
     it "the client_ip is empty" do
-      expect(request.client_ip).to be_nil
+      expect(attributes.client_ip).to be_nil
     end
   end
 
   context "with multiple forwarded addresses" do
-    let(:base) do
-      double('base request', env: {
+    let(:rack_request) do
+      double(:rack_request, env: {
                'HTTP_X_FORWARDED_FOR' => '10.0.0.2, 10.0.0.1'
              })
     end
-    let(:request) { described_class.new(base) }
 
     it "extracts the first address" do
-      expect(request.client_ip).to eq '10.0.0.2'
+      expect(attributes.client_ip).to eq '10.0.0.2'
     end
   end
 end


### PR DESCRIPTION
The purpose of this PR is to address some points I found confusing in these specs. The primary example is that sometimes an instance of Attributes was called 'request', and the mock of the rack_request was called 'base'.  Beyond those cosmetic changes, I wanted to prepare the specs as best as possible for the change to `Attributes#base` as outlined in the PFDR-107 comments, i.e. including user_pid, user_eid, client_ip, and auth_token in base.

* Uses consistent naming in all attributes specs
* Removes some unused setup from request/attributes_spec.rb
* Removes some unused tests from request/attributes_spec.rb that did not
  exercise functionality not already exercised by other tests.