### PR TITLE
PFDR-107

### DIFF
--- a/lib/keycard.rb
+++ b/lib/keycard.rb
@@ -18,3 +18,4 @@ require "keycard/db"
 require "keycard/railtie" if defined?(Rails)
 require "keycard/institution_finder"
 require "keycard/request"
+require "keycard/token"

--- a/lib/keycard/request/attributes.rb
+++ b/lib/keycard/request/attributes.rb
@@ -52,12 +52,23 @@ module Keycard::Request
       nil
     end
 
+    # The token supplied by the user via auth_param according to RFC 7235. Typically,
+    # this is the API token.
+    def auth_token
+      Keycard::Token.rfc7235(safe('HTTP_AUTHORIZATION'))
+    end
+
     # The set of base attributes for this request.
     #
     # Subclasses should implement user_pid, user_eid, and client_ip
     # and include them in the hash under those keys.
     def base
-      {}
+      {
+        user_pid: user_pid,
+        user_eid: user_eid,
+        client_ip: client_ip,
+        auth_token: auth_token
+      }
     end
 
     def [](attr)

--- a/lib/keycard/request/cosign_attributes.rb
+++ b/lib/keycard/request/cosign_attributes.rb
@@ -6,14 +6,6 @@ module Keycard::Request
   # the pid/eid are the same and there are currently no additional
   # attributes extracted.
   class CosignAttributes < Attributes
-    def base
-      {
-        user_pid:  user_pid,
-        user_eid:  user_eid,
-        client_ip: client_ip
-      }
-    end
-
     def user_pid
       get 'HTTP_X_REMOTE_USER'
     end

--- a/lib/keycard/request/direct_attributes.rb
+++ b/lib/keycard/request/direct_attributes.rb
@@ -5,14 +5,6 @@ module Keycard::Request
   # serve HTTP requests directly or through a proxy that passes trusted
   # values into the application environment to be accessed as usual.
   class DirectAttributes < Attributes
-    def base
-      {
-        user_pid:  user_pid,
-        user_eid:  user_eid,
-        client_ip: client_ip
-      }
-    end
-
     def user_pid
       get 'REMOTE_USER'
     end

--- a/lib/keycard/request/proxied_attributes.rb
+++ b/lib/keycard/request/proxied_attributes.rb
@@ -9,14 +9,6 @@ module Keycard::Request
   # which, somewhat confusingly, are transposed into HTTP_X_REMOTE_USER and
   # HTTP_X_FORWARDED_FOR once the Rack request is assembled.
   class ProxiedAttributes < Attributes
-    def base
-      {
-        user_pid:  user_pid,
-        user_eid:  user_eid,
-        client_ip: client_ip
-      }
-    end
-
     def user_pid
       get 'HTTP_X_REMOTE_USER'
     end

--- a/lib/keycard/request/shibboleth_attributes.rb
+++ b/lib/keycard/request/shibboleth_attributes.rb
@@ -10,19 +10,18 @@ module Keycard::Request
   # requests, and the user_pid, for requests from authenticated users.
   class ShibbolethAttributes < Attributes
     def base # rubocop:disable Metrics/MethodLength
-      {
-        user_pid:                   user_pid,
-        user_eid:                   user_eid,
-        client_ip:                  client_ip,
-        persistentNameID:           persistent_id,
-        eduPersonPrincipalName:     principal_name,
-        eduPersonScopedAffiliation: affiliation,
-        displayName:                display_name,
-        mail:                       email,
-        authnContextClassRef:       authn_context,
-        authenticationMethod:       authn_method,
-        identity_provider:          identity_provider
-      }
+      super.merge(
+        {
+          persistentNameID:           persistent_id,
+          eduPersonPrincipalName:     principal_name,
+          eduPersonScopedAffiliation: affiliation,
+          displayName:                display_name,
+          mail:                       email,
+          authnContextClassRef:       authn_context,
+          authenticationMethod:       authn_method,
+          identity_provider:          identity_provider
+        }
+      )
     end
 
     def user_pid

--- a/lib/keycard/token.rb
+++ b/lib/keycard/token.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Holds utility methods for parsing tokens from header values
+class Keycard::Token
+  TOKEN_DELIMS = /\s*[:,;\t]\s*/.freeze
+
+  class << self
+    def rfc7235(string)
+      string
+        .sub(/^(Bearer|Token):?/, '')
+        .split(TOKEN_DELIMS)
+        .map { |assignment| split_assignment(assignment) }
+        .to_h["token"]
+    end
+
+    private
+
+    # @param string_assignment [String] of the form 'key="value"'
+    # @return An array of pairs of key:value, both strings
+    def split_assignment(string_assignment)
+      clean_assignment(string_assignment)
+        .split('=')
+        .push('')
+        .slice(0, 2)
+    end
+
+    # @param string_assignment [String] of the form 'key="value"'
+    # @return [String] With the quotes and extraneous whitespace removed.
+    def clean_assignment(string_assignment)
+      string_assignment
+        .delete('"')
+        .strip
+    end
+  end
+end

--- a/spec/keycard/request/cosign_attributes_spec.rb
+++ b/spec/keycard/request/cosign_attributes_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Keycard::Request::CosignAttributes do
       expect(attributes.user_eid).to be_nil
     end
 
-    it "the client_ip is empty" do
+    it "the client_ip is empty (this would be a proxy configuration error)" do
       expect(attributes.client_ip).to be_nil
     end
   end

--- a/spec/keycard/request/proxied_attributes_spec.rb
+++ b/spec/keycard/request/proxied_attributes_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Keycard::Request::ProxiedAttributes do
       expect(attributes.user_eid).to be_nil
     end
 
-    it "the client_ip is empty" do
+    it "the client_ip is empty (this would be a proxy configuration error)" do
       expect(attributes.client_ip).to be_nil
     end
   end

--- a/spec/keycard/token_spec.rb
+++ b/spec/keycard/token_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "keycard/digest_key"
+require "securerandom"
+
+RSpec.describe Keycard::Token do
+  let(:token) { "somereallycooltoken" }
+  let(:header_value) { "Token token=\"#{token}\", opt=\"someopt\"" }
+
+  describe "::rfc7235" do
+    it "returns the token" do
+      expect(described_class.rfc7235(header_value)).to eql(token)
+    end
+  end
+end


### PR DESCRIPTION
See #12 for the spec cleanup branch this is based off of

Specific questions:
* `#base` is a bit wonky in `Attributes`. Pushing the `auth_token` implementation out is an option. Bringing in e.g. `DirectAttributes` such that it has no body is another. As-is is a workable third.
* Would we prefer `#auth_token` to return something other than a string? (It can also be nil...)

