### PR TITLE
Store timestamps in session as integers

### DIFF
--- a/lib/keycard/controller_methods.rb
+++ b/lib/keycard/controller_methods.rb
@@ -34,13 +34,13 @@ module Keycard
     def validate_session
       csrf_token = session[:_csrf_token]
       elapsed = begin
-                  Time.now - (session[:timestamp] || Time.at(0))
+                  Time.now - Time.at(session[:timestamp] || 0)
                 rescue StandardError
                   session_timeout
                 end
       reset_session if elapsed >= session_timeout
       session[:_csrf_token] = csrf_token
-      session[:timestamp] = Time.now if session.key?(:timestamp)
+      session[:timestamp] = Time.now.to_i if session.key?(:timestamp)
     end
 
     # Require that some authentication method successfully identifies a user/account,
@@ -105,7 +105,7 @@ module Keycard
       reset_session
       session[:return_to] = return_url
       session[:user_id] = current_user.id
-      session[:timestamp] = Time.now
+      session[:timestamp] = Time.now.to_i
     end
   end
 end

--- a/spec/keycard/controller_methods_spec.rb
+++ b/spec/keycard/controller_methods_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Keycard::ControllerMethods do
   subject(:controller) { FakeController.new(request, session, notary) }
 
   let(:request) { OpenStruct.new(env: {}) }
-  let(:session) { { timestamp: Time.now } }
+  let(:session) { { timestamp: Time.now.to_i} }
 
   before(:each) do
     allow(notary).to receive(:waive) do |account|
@@ -62,7 +62,7 @@ RSpec.describe Keycard::ControllerMethods do
 
     it "sets the session timestamp when logging in" do
       controller.login
-      expect(Time.now - session[:timestamp]).to be <= 1
+      expect(Time.now - Time.at(session[:timestamp])).to be <= 1
     end
 
     it "preserves the :return_to URL in session when logging in" do
@@ -86,7 +86,7 @@ RSpec.describe Keycard::ControllerMethods do
     it "sets the session timestamp when logging in" do
       user = double("User", id: 2)
       controller.auto_login(user)
-      expect(Time.now - session[:timestamp]).to be <= 1
+      expect(Time.now - Time.at(session[:timestamp])).to be <= 1
     end
 
     it "clears the current_user when doing logout" do


### PR DESCRIPTION
Before, this was storing the timestamp as a Time object in the session.
However, the default Rails cookie session store can't round-trip the
Time object and instead returns it as a string, which causes the session
to get reset every time.

This instead stores the time as an integral number of seconds since
1970, which I have verified can be round-tripped through the Rails
cookie session store (testing that is out of scope here)