### PR TITLE
Ruby 3 compatibility fixes

### DIFF
--- a/keycard.gemspec
+++ b/keycard.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "rubocop-rspec"
-  spec.add_development_dependency "sqlite3", "~> 1.3.13"
+  spec.add_development_dependency "sqlite3", "~> 1.4.2"
   spec.add_development_dependency "yard"
 end

--- a/lib/keycard/controller_methods.rb
+++ b/lib/keycard/controller_methods.rb
@@ -64,7 +64,7 @@ module Keycard
     #   passed to each authentication method
     # @return [Boolean] whether the login attempt was successful
     def login(**credentials)
-      authentication(credentials).authenticated?.tap do |success|
+      authentication(**credentials).authenticated?.tap do |success|
         setup_session if success
       end
     end
@@ -88,7 +88,7 @@ module Keycard
 
     def authentication(**credentials)
       request.env["keycard.authentication"] ||=
-        notary.authenticate(request, session, credentials)
+        notary.authenticate(request, session, **credentials)
     end
 
     # The session timeout, in seconds. Sessions will be cleared before any

--- a/lib/keycard/notary.rb
+++ b/lib/keycard/notary.rb
@@ -61,7 +61,7 @@ module Keycard
       attributes = attributes_factory.for(request)
       Authentication::Result.new.tap do |result|
         methods.find do |factory|
-          factory.call(attributes, session, result, credentials).apply
+          factory.call(attributes, session, result, **credentials).apply
         end
       end
     end


### PR DESCRIPTION
- Make double splat operators explicit when passing on `**credentials` parameters.
- Update to sqlite version that does not use deprecated `rb_check_safe_obj()` C API.